### PR TITLE
Fix a FAT32 type bug

### DIFF
--- a/crates/partitioning/src/formatter.rs
+++ b/crates/partitioning/src/formatter.rs
@@ -19,6 +19,9 @@ pub trait FilesystemExt {
 
     /// Returns the force format argument if applicable
     fn force_arg(&self) -> Vec<String>;
+
+    /// Returns arguments pinning the exact filesystem variant if needed
+    fn variant_arg(&self) -> Vec<String>;
 }
 
 impl FilesystemExt for Filesystem {
@@ -97,6 +100,14 @@ impl FilesystemExt for Filesystem {
             },
         }
     }
+
+    fn variant_arg(&self) -> Vec<String> {
+        match self {
+            // Never let mkfs.fat auto-select FAT12/16
+            Filesystem::Fat32 { .. } => vec!["-F".to_string(), "32".to_string()],
+            Filesystem::Standard { .. } => vec![],
+        }
+    }
 }
 
 /// Struct for formatting filesystems on devices
@@ -125,6 +136,8 @@ impl Formatter {
 
         cmd.args(self.filesystem.uuid_arg());
         cmd.args(self.filesystem.label_arg());
+        cmd.args(self.filesystem.variant_arg());
+
         if self.force {
             cmd.args(self.filesystem.force_arg());
         }

--- a/crates/partitioning/src/formatter.rs
+++ b/crates/partitioning/src/formatter.rs
@@ -103,7 +103,7 @@ impl FilesystemExt for Filesystem {
 
     fn variant_arg(&self) -> Vec<String> {
         match self {
-            // Never let mkfs.fat auto-select FAT12/16
+            // Strategy says fat32, don't let mkfs.fat downgrade to FAT12/16
             Filesystem::Fat32 { .. } => vec!["-F".to_string(), "32".to_string()],
             Filesystem::Standard { .. } => vec![],
         }

--- a/crates/types/src/filesystem.rs
+++ b/crates/types/src/filesystem.rs
@@ -15,6 +15,8 @@ use super::FromKdlProperty;
 /// This is used to format the partition with a filesystem
 #[derive(Debug, Clone, PartialEq)]
 pub enum Filesystem {
+    /// Used for ESP/XBOOTLDR partitions where the
+    /// privisioning strategy requires FAT32 regardless of partition size.
     Fat32 {
         label: Option<String>,
         volume_id: Option<u32>,


### PR DESCRIPTION
# Summary
The FAT32 type allowed the system to use FAT12/16 during auto provisioning because the -F 32 flag wasn't given in the mkfs.fat command.

## Fix
Added the -F 32 flag to the mkfs.fat command via helper function.