### PR TITLE
4Kn sector size enablement

### DIFF
--- a/crates/disks/src/disk.rs
+++ b/crates/disks/src/disk.rs
@@ -3,14 +3,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use core::fmt;
-use std::fs;
 use std::{
+    fs,
     ops::Deref,
     path::{Path, PathBuf},
 };
 
-use crate::SYSFS_DIR;
-use crate::{mmc, mock, nvme, partition::Partition, scsi, sysfs, virt};
+use crate::{SECTOR_SIZE, SYSFS_DIR, mmc, mock, nvme, partition::Partition, scsi, sysfs, virt};
 
 /// Represents the type of disk device.
 #[derive(Debug)]
@@ -58,6 +57,8 @@ pub struct BasicDisk {
     pub(crate) vendor: Option<String>,
     /// Partitions
     pub(crate) partitions: Vec<Partition>,
+    /// Addressable block size in bytes, 512 or 4096
+    pub(crate) logical_block_size: u64,
 }
 
 impl fmt::Display for Disk {
@@ -114,7 +115,12 @@ impl BasicDisk {
 
     /// Returns the size of the disk in bytes.
     pub fn size(&self) -> u64 {
-        self.sectors() * 512
+        self.sectors() * SECTOR_SIZE
+    }
+
+    /// Returns the addressable block size in bytes.
+    pub fn logical_block_size(&self) -> u64 {
+        self.logical_block_size
     }
 
     /// Returns the model name of the disk.
@@ -172,6 +178,9 @@ impl DiskInit for BasicDisk {
         let vendor = sysfs::read(&node, "device/vendor");
         log::debug!("Vendor: {vendor:?}");
 
+        let logical_block_size = sysfs::read(&node, "queue/logical_block_size").unwrap_or(SECTOR_SIZE);
+        log::debug!("Logical block size: {logical_block_size}");
+
         Some(Self {
             name: name.to_owned(),
             sectors,
@@ -179,6 +188,7 @@ impl DiskInit for BasicDisk {
             model,
             vendor,
             partitions,
+            logical_block_size,
         })
     }
 }

--- a/crates/disks/src/lib.rs
+++ b/crates/disks/src/lib.rs
@@ -24,6 +24,7 @@ pub mod virt;
 
 const SYSFS_DIR: &str = "sys/class/block";
 const DEVFS_DIR: &str = "dev";
+pub const SECTOR_SIZE: u64 = 512;
 
 /// A block device on the system which can be either a physical disk or a partition.
 #[derive(Debug)]
@@ -53,7 +54,15 @@ impl BlockDevice {
 
     /// Returns the total size of the block device in bytes.
     pub fn size(&self) -> u64 {
-        self.sectors() * 512
+        self.sectors() * SECTOR_SIZE
+    }
+
+    /// Returns the addressable block size in bytes, 512 or 4096.
+    pub fn logical_block_size(&self) -> u64 {
+        match self {
+            BlockDevice::Disk(disk) => disk.logical_block_size(),
+            BlockDevice::Loopback(device) => device.disk().map_or(SECTOR_SIZE, |dev| dev.logical_block_size()),
+        }
     }
 
     /// Returns the partitions on the block device.
@@ -171,6 +180,18 @@ impl BlockDevice {
 
         Ok(devices)
     }
+}
+
+/// The addressable block size of tha whole disk device.
+///
+/// Falls back to 512 when the attribute cannot be read, matching the kernel
+/// default for devices that do not report one.
+pub fn logical_block_size_of(device: &Path) -> u64 {
+    let Some(name) = device.file_name() else {
+        return SECTOR_SIZE;
+    };
+
+    sysfs::read(&Path::new("/").join(SYSFS_DIR).join(name), "queue/logical_block_size").unwrap_or(SECTOR_SIZE)
 }
 
 #[cfg(test)]

--- a/crates/disks/src/lib.rs
+++ b/crates/disks/src/lib.rs
@@ -182,7 +182,7 @@ impl BlockDevice {
     }
 }
 
-/// The addressable block size of tha whole disk device.
+/// The addressable block size of the whole disk device.
 ///
 /// Falls back to 512 when the attribute cannot be read, matching the kernel
 /// default for devices that do not report one.

--- a/crates/disks/src/mock.rs
+++ b/crates/disks/src/mock.rs
@@ -35,7 +35,12 @@ impl MockDisk {
     }
 
     pub fn new_with_name(name: &str, size_bytes: u64, parts_prefix: bool) -> Self {
-        let sectors = size_bytes / 512;
+        Self::new_with_block_size(name, size_bytes, parts_prefix, crate::SECTOR_SIZE)
+    }
+
+    pub fn new_with_block_size(name: &str, size_bytes: u64, parts_prefix: bool, logical_block_size: u64) -> Self {
+        // Sysfs counts in 512-byte units whatever the logical block size is
+        let sectors = size_bytes / crate::SECTOR_SIZE;
         let disk = BasicDisk {
             name: name.to_string(),
             sectors,
@@ -43,6 +48,7 @@ impl MockDisk {
             model: Some("Mock Device".to_string()),
             vendor: Some("Mock Vendor".to_string()),
             partitions: Vec::new(),
+            logical_block_size,
         };
 
         Self {

--- a/crates/disks/src/partition.rs
+++ b/crates/disks/src/partition.rs
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::fmt;
-use std::path::{Path, PathBuf};
-
-use crate::{DEVFS_DIR, SYSFS_DIR, sysfs};
+use crate::{DEVFS_DIR, SECTOR_SIZE, SYSFS_DIR, sysfs};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
 
 /// Represents a partition on a disk device
 /// - Size in sectors
@@ -33,7 +34,7 @@ impl fmt::Display for Partition {
             f,
             "{name} {size:.2} GiB",
             name = self.name,
-            size = self.size as f64 * 512.0 / (1024.0 * 1024.0 * 1024.0)
+            size = self.size_bytes() as f64 / (1024.0 * 1024.0 * 1024.0)
         )
     }
 }
@@ -62,5 +63,20 @@ impl Partition {
             node,
             device: sysroot.join(DEVFS_DIR).join(name),
         })
+    }
+
+    /// Absolute start offset of the partition, in bytes
+    pub fn start_bytes(&self) -> u64 {
+        self.start * SECTOR_SIZE
+    }
+
+    /// Absolute end offset of the partition, in bytes
+    pub fn end_bytes(&self) -> u64 {
+        self.end * SECTOR_SIZE
+    }
+
+    /// Size of the partition, in bytes
+    pub fn size_bytes(&self) -> u64 {
+        self.size * SECTOR_SIZE
     }
 }

--- a/crates/partitioning/src/blkpg.rs
+++ b/crates/partitioning/src/blkpg.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use disks::{BasicDisk, DiskInit};
+use gpt::{GptConfig, disk::LogicalBlockSize};
 use log::{debug, error, info};
 use std::{
     fs::File,
@@ -163,15 +164,18 @@ pub fn remove_kernel_partitions<P: AsRef<Path>>(path: P) -> Result<(), Error> {
 ///
 /// # Returns
 /// `Result<(), Error>` indicating success or partition operation failure
-pub fn create_kernel_partitions<P: AsRef<Path>>(path: P) -> Result<(), Error> {
+pub fn create_kernel_partitions<P: AsRef<Path>>(path: P, logical_block_size: u64) -> Result<(), Error> {
     info!("Creating kernel partitions from GPT for {:?}", path.as_ref());
     let file = File::open(&path)?;
 
     // Read GPT table
     debug!("Reading GPT partition table");
-    let gpt = gpt::GptConfig::new().writable(false).open(&path)?;
+    let gpt = GptConfig::new()
+        .writable(false)
+        .logical_block_size(LogicalBlockSize::try_from(logical_block_size)?)
+        .open(&path)?;
     let partitions = gpt.partitions();
-    let block_size = 512;
+    let block_size = logical_block_size as i64;
     info!("Located {} partitions (block size: {})", partitions.len(), block_size);
 
     // Add partitions from GPT
@@ -200,7 +204,7 @@ pub fn sync_gpt_partitions<P: AsRef<Path>>(path: P) -> Result<(), Error> {
     info!("Initiating GPT partition synchronization for {:?}", path.as_ref());
 
     remove_kernel_partitions(&path)?;
-    create_kernel_partitions(&path)?;
+    create_kernel_partitions(&path, disks::logical_block_size_of(path.as_ref()))?;
 
     info!("GPT partition synchronization completed successfully");
     Ok(())

--- a/crates/partitioning/src/planner.rs
+++ b/crates/partitioning/src/planner.rs
@@ -175,7 +175,7 @@ impl Planner {
         let mut max_id = 0u32;
 
         for part in device.partitions() {
-            let mut region = Region::new(part.start, part.end);
+            let mut region = Region::new(part.start_bytes(), part.end_bytes());
             region.partition_id = Some(part.number);
             original_regions.push(region);
             original_partition_ids.push(part.number);
@@ -683,5 +683,21 @@ mod tests {
         let layout = planner.current_layout();
         assert_eq!(layout[0].partition_id, Some(1));
         assert_eq!(layout[1].partition_id, Some(2));
+    }
+
+    #[test]
+    fn test_existing_partitions_are_modelled_in_bytes() {
+        let mut disk = create_mock_disk();
+        disk.add_partition(0, 100 * MB);
+        disk.add_partition(100 * MB, 200 * MB);
+
+        let planner = Planner::new(&BlockDevice::mock_device(disk));
+        let layout = planner.current_layout();
+
+        assert_eq!(layout.len(), 2);
+        assert_eq!(layout[0].start, 0);
+        assert_eq!(layout[0].end, 100 * MB);
+        assert_eq!(layout[1].start, 100 * MB);
+        assert_eq!(layout[1].end, 200 * MB);
     }
 }

--- a/crates/partitioning/src/writer.rs
+++ b/crates/partitioning/src/writer.rs
@@ -3,20 +3,17 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{
-    fs,
-    io::{self, Seek, Write},
-};
-
-use disks::BlockDevice;
-use gpt::{GptConfig, mbr, partition_types};
-use thiserror::Error;
-
 use crate::{
     GptAttributes, blkpg,
     planner::{Change, Planner},
 };
-const SECTOR_SIZE: u64 = 512;
+use disks::BlockDevice;
+use gpt::{GptConfig, disk::LogicalBlockSize, mbr, partition_types};
+use std::{
+    fs,
+    io::{self, Seek, Write},
+};
+use thiserror::Error;
 
 /// Errors that can occur when writing changes to disk
 #[derive(Debug, Error)]
@@ -24,22 +21,21 @@ pub enum WriteError {
     // A blkpg error
     #[error("error syncing partitions: {0}")]
     Blkpg(#[from] blkpg::Error),
-
     /// A partition ID was used multiple times
     #[error("Duplicate partition ID: {0}")]
     DuplicatePartitionId(u32),
-
     /// Error from GPT library
     #[error("GPT error: {0}")]
     Gpt(#[from] gpt::GptError),
-
     /// Error from MBR handling
     #[error("GPT error: {0}")]
     Mbr(#[from] gpt::mbr::MBRError),
-
     /// Underlying I/O error
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
+    /// The device reports a block size GPT cannot address
+    #[error("unsupported logical block size {0}, must be 512 or 4096")]
+    UnsupportedBlockSize(u64),
 }
 
 /// A writer that applies the layouts from the Planner to the disk.
@@ -143,31 +139,36 @@ impl<'a> DiskWriter<'a> {
 
         let mut zero_regions = vec![];
 
+        let block_size = self.device.logical_block_size();
+        let lb_size =
+            LogicalBlockSize::try_from(block_size).map_err(|_| WriteError::UnsupportedBlockSize(block_size))?;
         let mut gpt_table = if self.planner.wipe_disk() {
             if writable {
-                // Zero out headers including potential ISO structures
                 zero_disk_headers(device)?;
 
-                // Convert total bytes to LBA sectors, subtract 1 as per GPT spec
-                let total_lba = self.device.size() / SECTOR_SIZE;
+                // Convert total bytes to Logical Block Allocation sectors, subtract 1 as per GPT spec
+                let total_lba = self.device.size() / block_size;
                 let mbr = mbr::ProtectiveMBR::with_lb_size(
                     u32::try_from(total_lba.saturating_sub(1)).unwrap_or(0xFF_FF_FF_FF),
                 );
-                eprintln!("size is {}", self.device.size());
                 mbr.overwrite_lba0(device)?;
             }
 
-            let mut c = GptConfig::default()
+            let mut gpt_conf = GptConfig::default()
                 .writable(writable)
-                .logical_block_size(gpt::disk::LogicalBlockSize::Lb512)
+                .logical_block_size(lb_size)
                 .create_from_device(device, None)?;
 
             if writable {
-                c.write_inplace()?;
+                gpt_conf.write_inplace()?;
             }
-            c
+
+            gpt_conf
         } else {
-            GptConfig::default().writable(writable).open_from_device(device)?
+            GptConfig::default()
+                .writable(writable)
+                .logical_block_size(lb_size)
+                .open_from_device(device)?
         };
 
         let layout = self.planner.current_layout();
@@ -192,9 +193,9 @@ impl<'a> DiskWriter<'a> {
                     attributes,
                 } => {
                     // Convert byte offsets to LBA sectors
-                    let start_lba = *start / SECTOR_SIZE;
+                    let start_lba = *start / block_size;
                     let size_bytes = *end - *start;
-                    let size_lba = size_bytes / SECTOR_SIZE;
+                    let size_lba = size_bytes / block_size;
                     let (part_type, part_name) = match attributes.as_ref().and_then(|a| a.table.as_gpt()) {
                         Some(GptAttributes { type_guid, name, .. }) => {
                             (type_guid.clone(), name.clone().unwrap_or_default())
@@ -238,7 +239,7 @@ impl<'a> DiskWriter<'a> {
                 zero_partition_prefix(original, start, end - start)?;
             }
 
-            blkpg::create_kernel_partitions(self.device.device())?;
+            blkpg::create_kernel_partitions(self.device.device(), block_size)?;
         }
 
         Ok(())

--- a/crates/types/src/filesystem.rs
+++ b/crates/types/src/filesystem.rs
@@ -16,7 +16,7 @@ use super::FromKdlProperty;
 #[derive(Debug, Clone, PartialEq)]
 pub enum Filesystem {
     /// Used for ESP/XBOOTLDR partitions where the
-    /// privisioning strategy requires FAT32 regardless of partition size.
+    /// provisioning strategy requires FAT32 regardless of partition size.
     Fat32 {
         label: Option<String>,
         volume_id: Option<u32>,


### PR DESCRIPTION
# Summary
Here's an explanation of where the problem came from and how it was fixed. Resolves issue #34.

## The Problem
The code assumed 512-byte sectors in every place it converted between byte offsets and GPT logical block addresses.

- `queue/logical_block_size` (512 or 4096) is the unit GPT addresses in. It was never read,  so every byte to logical byte address conversion assumed 512.


## The Fix
It now reads the drive's actual logical block size and uses it for the GPT and Kernel partition work. It leaves the sysfs sector reads alone, since those are always 512-byte units regardless of the disk.

- Added a `SECTOR_SIZE` const for the 512-byte sysfs unit and replaced the bare literals, plus `Partition::start_bytes`/`end_bytes`/`size_bytes` so the sector to byte conversion has a name instead of being bare magic numbers.
- Read `queue/logical_block_size` at discovery, store it on `BasicDisk`, and expose `Disk::logical_block_size` and `BlockDevice::logical_block_size`.
  - **NOTE**: *Defaults to 512 when the attribute is missing.*
- Added `logical_block_size_of(&Path)` for callers holding only a device node.
- Added `MockDisk::new_with_block_size` so 4Kn can be tested without hardware.
- Now derives the block size from the device and uses it for the GPT config, the protective MBR total, and the partition logical block address conversions.
- Now rejects a block size other than 512 or 4096 instead of silently assuming 512.
- `create_kernel_partitions` now takes the block size, uses it to open the GPT and to convert logical block addresses back to by offsets for BLKPG.
- `sync_gpt_partitions` derives it from the path and keeps its signature.

***NOTE***: *Full fix will be in after this PR is accepted so that the lichen_installer portion of the fix can be opened and merged.*