### PR TITLE
Btrfs bcachefs linux root

### DIFF
--- a/crates/partitioning/src/formatter.rs
+++ b/crates/partitioning/src/formatter.rs
@@ -32,6 +32,8 @@ impl FilesystemExt for Filesystem {
                 types::StandardFilesystemType::F2fs => "mkfs.f2fs",
                 types::StandardFilesystemType::Ext4 => "mkfs.ext4",
                 types::StandardFilesystemType::Xfs => "mkfs.xfs",
+                types::StandardFilesystemType::Btrfs => "mkfs.btrfs",
+                types::StandardFilesystemType::Bcachefs => "mkfs.bcachefs",
                 types::StandardFilesystemType::Swap => "mkswap",
             },
         }
@@ -54,6 +56,8 @@ impl FilesystemExt for Filesystem {
                         types::StandardFilesystemType::Ext4 => vec!["-U".to_string(), uuid.to_string()],
                         types::StandardFilesystemType::F2fs => vec!["-U".to_string(), uuid.to_string()],
                         types::StandardFilesystemType::Xfs => vec!["-m".to_string(), format!("uuid={}", uuid)],
+                        types::StandardFilesystemType::Btrfs => vec!["-U".to_string(), uuid.to_string()],
+                        types::StandardFilesystemType::Bcachefs => vec!["-U".to_string(), uuid.to_string()],
                         types::StandardFilesystemType::Swap => vec!["-U".to_string(), uuid.to_string()],
                     }
                 } else {
@@ -80,6 +84,8 @@ impl FilesystemExt for Filesystem {
                         types::StandardFilesystemType::Ext4 => vec!["-L".to_string(), label.to_string()],
                         types::StandardFilesystemType::F2fs => vec!["-l".to_string(), label.to_string()],
                         types::StandardFilesystemType::Xfs => vec!["-L".to_string(), label.to_string()],
+                        types::StandardFilesystemType::Btrfs => vec!["-L".to_string(), label.to_string()],
+                        types::StandardFilesystemType::Bcachefs => vec!["-L".to_string(), label.to_string()],
                         types::StandardFilesystemType::Swap => vec!["-L".to_string(), label.to_string()],
                     }
                 } else {
@@ -96,6 +102,8 @@ impl FilesystemExt for Filesystem {
                 types::StandardFilesystemType::F2fs => vec!["-f".to_string()],
                 types::StandardFilesystemType::Ext4 => vec!["-F".to_string()],
                 types::StandardFilesystemType::Xfs => vec!["-f".to_string()],
+                types::StandardFilesystemType::Btrfs => vec!["-f".to_string()],
+                types::StandardFilesystemType::Bcachefs => vec!["-f".to_string()],
                 types::StandardFilesystemType::Swap => vec!["-f".to_string()],
             },
         }
@@ -190,5 +198,35 @@ mod tests {
         assert_eq!(fs.mkfs_command(), "mkfs.xfs");
         assert_eq!(fs.uuid_arg(), vec!["-m".to_string(), format!("uuid={uuid}")]);
         assert_eq!(fs.label_arg(), vec!["-L", "data"]);
+    }
+
+    #[test]
+    fn test_btrfs_args() {
+        let uuid = Uuid::new_v4();
+        let fs = Filesystem::Standard {
+            filesystem_type: types::StandardFilesystemType::Btrfs,
+            label: Some("data".to_string()),
+            uuid: Some(uuid.to_string()),
+        };
+
+        assert_eq!(fs.mkfs_command(), "mkfs.btrfs");
+        assert_eq!(fs.uuid_arg(), vec!["-U".to_string(), uuid.to_string()]);
+        assert_eq!(fs.label_arg(), vec!["-L", "data"]);
+        assert_eq!(fs.force_arg(), vec!["-f"]);
+    }
+
+    #[test]
+    fn test_bcachefs_args() {
+        let uuid = Uuid::new_v4();
+        let fs = Filesystem::Standard {
+            filesystem_type: types::StandardFilesystemType::Bcachefs,
+            label: Some("home".to_string()),
+            uuid: Some(uuid.to_string()),
+        };
+
+        assert_eq!(fs.mkfs_command(), "mkfs.bcachefs");
+        assert_eq!(fs.uuid_arg(), vec!["-U".to_string(), uuid.to_string()]);
+        assert_eq!(fs.label_arg(), vec!["-L", "home"]);
+        assert_eq!(fs.force_arg(), vec!["-f"]);
     }
 }

--- a/crates/types/src/filesystem.rs
+++ b/crates/types/src/filesystem.rs
@@ -33,6 +33,8 @@ pub enum StandardFilesystemType {
     F2fs,
     Ext4,
     Xfs,
+    Btrfs,
+    Bcachefs,
     Swap,
 }
 
@@ -42,6 +44,8 @@ impl fmt::Display for StandardFilesystemType {
             Self::Ext4 => f.write_str("ext4"),
             Self::F2fs => f.write_str("f2fs"),
             Self::Xfs => f.write_str("xfs"),
+            Self::Btrfs => f.write_str("btrfs"),
+            Self::Bcachefs => f.write_str("bachefs"),
             Self::Swap => f.write_str("swap"),
         }
     }
@@ -55,6 +59,8 @@ impl FromStr for StandardFilesystemType {
             "ext4" => Ok(Self::Ext4),
             "f2fs" => Ok(Self::F2fs),
             "xfs" => Ok(Self::Xfs),
+            "btrfs" => Ok(Self::Btrfs),
+            "bcachefs" => Ok(Self::Bcachefs),
             "swap" => Ok(Self::Swap),
             _ => Err(crate::Error::UnknownVariant),
         }
@@ -67,7 +73,7 @@ impl FromKdlProperty<'_> for StandardFilesystemType {
         let value = kdl_value_to_string(entry)?;
         let v = value.parse().map_err(|_| crate::UnsupportedValue {
             at: entry.span(),
-            advice: Some("'fat32', 'ext4', 'f2fs', 'xfs' 'swap' are supported".into()),
+            advice: Some("'fat32', 'ext4', 'f2fs', 'xfs', 'btrfs', 'bcachefs', 'swap' are supported".into()),
         })?;
         Ok(v)
     }

--- a/crates/types/src/filesystem.rs
+++ b/crates/types/src/filesystem.rs
@@ -45,7 +45,7 @@ impl fmt::Display for StandardFilesystemType {
             Self::F2fs => f.write_str("f2fs"),
             Self::Xfs => f.write_str("xfs"),
             Self::Btrfs => f.write_str("btrfs"),
-            Self::Bcachefs => f.write_str("bachefs"),
+            Self::Bcachefs => f.write_str("bcachefs"),
             Self::Swap => f.write_str("swap"),
         }
     }

--- a/crates/types/src/partition_type.rs
+++ b/crates/types/src/partition_type.rs
@@ -64,6 +64,7 @@ pub enum PartitionTypeGuid {
     ExtendedBootLoader,
     LinuxSwap,
     LinuxFilesystem,
+    LinuxRoot,
 }
 
 impl fmt::Display for PartitionTypeGuid {
@@ -72,6 +73,7 @@ impl fmt::Display for PartitionTypeGuid {
             Self::EfiSystemPartition => f.write_str("EFI System Partition"),
             Self::ExtendedBootLoader => f.write_str("Linux Extended Boot"),
             Self::LinuxFilesystem => f.write_str("Linux Filesystem"),
+            Self::LinuxRoot => f.write_str("Linux Root"),
             Self::LinuxSwap => f.write_str("Linux Swap"),
         }
     }
@@ -86,6 +88,7 @@ impl FromStr for PartitionTypeGuid {
             "linux-extended-boot" => Ok(Self::ExtendedBootLoader),
             "linux-swap" => Ok(Self::LinuxSwap),
             "linux-fs" => Ok(Self::LinuxFilesystem),
+            "linux-root" => Ok(Self::LinuxRoot),
             _ => Err(crate::Error::UnknownVariant),
         }
     }
@@ -99,6 +102,7 @@ impl PartitionTypeGuid {
             Self::ExtendedBootLoader => gpt::partition_types::FREEDESK_BOOT,
             Self::LinuxSwap => gpt::partition_types::LINUX_SWAP,
             Self::LinuxFilesystem => gpt::partition_types::LINUX_FS,
+            Self::LinuxRoot => gpt::partition_types::LINUX_ROOT_X64,
         }
     }
 
@@ -108,7 +112,7 @@ impl PartitionTypeGuid {
         let v = value.parse().map_err(|_| crate::UnsupportedValue {
             at: node.span(),
             advice: Some(
-                "'efi-system-partition', 'linux-swap' 'linux-extended-boot' and 'linux-fs' are supported".into(),
+                "'efi-system-partition', 'linux-swap' 'linux-extended-boot', 'linux-fs', and 'linux-root' are supported".into(),
             ),
         })?;
         Ok(v)


### PR DESCRIPTION
# Summary
Add `btrfs` and `bcachefs` as format targets, and the `Linux Root (x86-64)` partition type so root partitions can be marked discoverable. Enable the btrfs/bcachesfs root work in lichen_installer.

## Additions
- Add `btrfs` and `bcachefs` to `StandardFileSystemType` with Display, FrmStr, and KDL parsing, and wire both into `FilesystemExt`.
  - **NOTE**: *bcachefs uses -L for the filesystem lable, not -l.*
- Add a `LinuxRoot` variant to `PartitionTypeGuid` (Display, FromStr as linux-root, as_guid -> LINUX_ROOT_X64) so strategies can stamp the discoverable root type on a root partition.
- Add arg tests for the new filesystems.