### PR TITLE
Xfs tuning

### DIFF
--- a/crates/partitioning/src/formatter.rs
+++ b/crates/partitioning/src/formatter.rs
@@ -222,6 +222,67 @@ mod tests {
     }
 
     #[test]
+    fn test_xfs_format_command_order() {
+        let uuid = Uuid::new_v4();
+        let fs = Filesystem::Standard {
+            filesystem_type: types::StandardFilesystemType::Xfs,
+            label: Some("ROOT".to_string()),
+            uuid: Some(uuid.to_string()),
+        };
+        let formatter = Formatter::new(fs).force();
+        let command = formatter.format(Path::new("/dev/test_device"));
+        let program = command.get_program().to_string_lossy();
+        let args: Vec<String> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+
+        assert_eq!(program, "mkfs.xfs");
+        assert_eq!(
+            args,
+            vec![
+                "-m".to_string(),
+                format!("uuid={uuid}"),
+                "-L".to_string(),
+                "ROOT".to_string(),
+                "-n".to_string(),
+                "parent=1".to_string(),
+                "-i".to_string(),
+                "exchange=1".to_string(),
+                "-m".to_string(),
+                "autofsck=repair".to_string(),
+                "-f".to_string(),
+                "/dev/test_device".to_string(),
+            ]
+        );
+
+        // mkfs.xfs accepts multiple -m sections, but each key must appear only once
+        // within its own section. Verify uuid and autofsck weren't accidentally merged
+        // into the same -m argument list.
+        let mut seen_m_section = false;
+        let mut iter = args.iter();
+
+        while let Some(arg) = iter.next() {
+            if arg == "-m" {
+                let value = iter.next().expect("expected value after -m");
+                if seen_m_section {
+                    assert!(
+                        value.starts_with("autofsck="),
+                        "second -m section must only carry autofsck, got: {value}"
+                    );
+                } else {
+                    assert!(
+                        value.starts_with("uuid="),
+                        "first -m section must carry uuid, got: {value}"
+                    );
+                    seen_m_section = true;
+                }
+            }
+        }
+        assert!(seen_m_section, "expected at least one -m section");
+    }
+
+    #[test]
     fn test_btrfs_args() {
         let uuid = Uuid::new_v4();
         let fs = Filesystem::Standard {

--- a/crates/partitioning/src/formatter.rs
+++ b/crates/partitioning/src/formatter.rs
@@ -113,7 +113,23 @@ impl FilesystemExt for Filesystem {
         match self {
             // Strategy says fat32, don't let mkfs.fat downgrade to FAT12/16
             Filesystem::Fat32 { .. } => vec!["-F".to_string(), "32".to_string()],
-            Filesystem::Standard { .. } => vec![],
+            Filesystem::Standard { filesystem_type, .. } => {
+                match filesystem_type {
+                    // XFS online self-repair: parent pointers so xfs_scrub can rebuild
+                    // directories, atomic exchange-range so it can swap in repaired
+                    // metadata, and autofsck=repair so the scheduled scrub fixes what it
+                    // finds. crc/rmapbt/reflink are already mkfs.xfs defaults.
+                    types::StandardFilesystemType::Xfs => vec![
+                        "-n".to_string(),
+                        "parent=1".to_string(),
+                        "-i".to_string(),
+                        "exchange=1".to_string(),
+                        "-m".to_string(),
+                        "autofsck=repair".to_string(),
+                    ],
+                    _ => vec![],
+                }
+            }
         }
     }
 }
@@ -184,6 +200,7 @@ mod tests {
         assert_eq!(fs.mkfs_command(), "mkfs.ext4");
         assert_eq!(fs.uuid_arg(), vec!["-U".to_string(), uuid.to_string()]);
         assert_eq!(fs.label_arg(), vec!["-L", "root"]);
+        assert!(fs.variant_arg().is_empty());
     }
 
     #[test]
@@ -198,6 +215,10 @@ mod tests {
         assert_eq!(fs.mkfs_command(), "mkfs.xfs");
         assert_eq!(fs.uuid_arg(), vec!["-m".to_string(), format!("uuid={uuid}")]);
         assert_eq!(fs.label_arg(), vec!["-L", "data"]);
+        assert_eq!(
+            fs.variant_arg(),
+            vec!["-n", "parent=1", "-i", "exchange=1", "-m", "autofsck=repair"]
+        );
     }
 
     #[test]

--- a/crates/superblock/src/xfs.rs
+++ b/crates/superblock/src/xfs.rs
@@ -142,7 +142,7 @@ pub struct Xfs {
     /// Compatible feature flags
     pub features_compat: U32<BigEndian>,
     /// Read-only compatible feature flags
-    pub features_ro_cmopat: U32<BigEndian>,
+    pub features_ro_compat: U32<BigEndian>,
     /// Incompatible feature flags
     pub features_incompat: U32<BigEndian>,
     /// Log incompatible feature flags


### PR DESCRIPTION
# Summary
  
Improve XFS root/data filesystem reliability by passing format-time flags that enable online self-repair and periodic scrubbing. Btrfs and other filesystems are untouched.

## Additions
- `crates/partitioning/src/formatter.rs` emits XFS reliability flags through `variant_arg()`:  
  - -n parent=1 enables parent pointers so `xfs_scrub` can rebuild directory trees.
  - -i exchange=1 enabled atomic exchange-range metadata repair.
  - -m autofsck=repair makes the scheduled scrub fix issues it finds.
- `uuid_arg()`, `label_arg()`, and `-f` force handling for XFS remain unchanged.
- Add `test_xfs_format_command_order` to verify the full `mkfs.xfs` argument order and confirm `uuid=...` and `autofsck=...` liv in separate `-m` sections.
  
## Notes
  
- `crc`, `rmapbt`, and `reflink` are already `mkfs.xfs` defaults, so they are not passed explicitly.
- Fixed a typo in `crates/superblock/src/xfs.rs`: features_ro_cmopat -> features_ro_compat.