### PR TITLE
update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -50,8 +50,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.28.1
+      - uses: actions/checkout@v7
+      - uses: crate-ci/typos@v1.48.0
 
   machete:
     name: Check for Unused Dependencies
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run cargo-machete
-        uses: bnjbvr/cargo-machete@v0.8.0
+        uses: bnjbvr/cargo-machete@v0.9.2


### PR DESCRIPTION
## Summary

Update github actions to their respective latest versions:

- actions/checkout v4 to v7
- crate-ci/typos v1.28.1 to v1.48.0
- bnjbvr/cargo-machete v0.8.0 to v0.9.2

## Testing

I haven't tested as I think this needs to go live and then run through github actions